### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For generating the required output, I created this prompt. Feel free to modify i
 
 ## Known Issues
 
-- Minor Lag when the response is fetched from backend and converted to Audio format. Can depend on Device to Devcie
+- Minor Lag when the response is fetched from backend and converted to Audio format. Can depend on Device to Device
 
 ## Contributing
 


### PR DESCRIPTION
Corrected "Devcie" to "Device" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.